### PR TITLE
Python3 fixed in cloudpickle.py

### DIFF
--- a/python/pyspark/cloudpickle.py
+++ b/python/pyspark/cloudpickle.py
@@ -187,7 +187,7 @@ class CloudPickler(pickle.Pickler):
             self.save_reduce(_get_module_builtins, (), obj=obj)
         else:
             pickle.Pickler.save_dict(self, obj)
-    dispatch[pickle.DictionaryType] = save_dict
+    dispatch[dict] = save_dict
 
 
     def save_module(self, obj, pack=struct.pack):


### PR DESCRIPTION
Hiya Josh,
This is my bull-in-a-china-shop quick attempt to address some of the python 3 issues in cloudpickle.py. A few of them I'm not sure about (buffer in 2.x vs memoryview in 3.x, types.InstanceType on 2.x vs object in 3.x), but I was able to import/run the module with python 3.4 after the changes. I regrettably don't have spark built at the moment so can't run the tests, but here's hoping this is at least helpful.
